### PR TITLE
Update wxLB_MULTIPLE to wxLB_EXTENDED for wxListBoxes

### DIFF
--- a/place_by_reference_GUI.fbp
+++ b/place_by_reference_GUI.fbp
@@ -171,7 +171,7 @@
                         <property name="resize">Resizable</property>
                         <property name="show">1</property>
                         <property name="size"></property>
-                        <property name="style">wxLB_MULTIPLE|wxLB_NEEDED_SB</property>
+                        <property name="style">wxLB_EXTENDED|wxLB_NEEDED_SB</property>
                         <property name="subclass">; forward_declare</property>
                         <property name="toolbar_pane">0</property>
                         <property name="tooltip"></property>

--- a/place_by_sheet_GUI.fbp
+++ b/place_by_sheet_GUI.fbp
@@ -316,7 +316,7 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size">230,-1</property>
-                                <property name="style">wxLB_MULTIPLE|wxLB_NEEDED_SB</property>
+                                <property name="style">wxLB_EXTENDED|wxLB_NEEDED_SB</property>
                                 <property name="subclass">; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>


### PR DESCRIPTION
Adds support for multiple items selection using mouse and SHIFT/CTRL keys.
Could be useful if one have multiple footprints but only wants to place some of them.